### PR TITLE
chore: verify vault secrets after team-scoped AppRole migration

### DIFF
--- a/.github/workflows/VERIFY_VAULT_SECRETS.yml
+++ b/.github/workflows/VERIFY_VAULT_SECRETS.yml
@@ -1,0 +1,43 @@
+name: Verify Vault Secrets
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/VERIFY_VAULT_SECRETS.yml"
+
+jobs:
+  verify-vault-secrets:
+    name: Verify Vault access
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Secrets (cambpm)
+        id: secrets-cambpm
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/cambpm/ci/github-workflow GITHUB_APP_ID;
+            secret/data/products/cambpm/ci/github-workflow GITHUB_APP_PRIVATE_KEY;
+
+      - name: Import Secrets (org)
+        id: secrets-org
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+
+      - name: Verify all secrets loaded
+        run: |
+          echo "✅ All Vault secrets imported successfully"
+          echo "  - cambpm: GITHUB_APP_ID present=${{ steps.secrets-cambpm.outputs.GITHUB_APP_ID != '' }}"
+          echo "  - org: NEXUS_USR present=${{ steps.secrets-org.outputs.NEXUS_USR != '' }}"


### PR DESCRIPTION
Temporary verification workflow to confirm Vault access works after migration to team-scoped AppRole (cambpm).

Related to camunda/team-infrastructure#867

**This PR will be closed after verification.**