### PR TITLE
ci(docs): add reusable Hugo build action

### DIFF
--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -59,3 +59,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `ruby`, and `python3`.

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -59,4 +59,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
-- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, and `ruby`.
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `ruby`, and either `sha256sum` or `shasum`.

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -1,0 +1,61 @@
+# docs-hugo-build
+
+Reusable composite action to build Hugo docs with a pinned Hugo version.
+
+This action is part of the docs release migration foundation slice for `camunda/camunda-bpm-platform-maintenance#3005`, focused only on deterministic docs build behavior.
+
+## Public-safe scope
+
+The action is intentionally generic and repository-agnostic:
+
+- no SSH
+- no rsync
+- no Vault
+- no deployment
+- no Jenkins cleanup behavior
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `source` | Yes | - | Path to the Hugo site/project directory |
+| `destination` | No | - | Optional Hugo output directory (`--destination`) |
+| `hugo-version` | No | `0.54.0` | Hugo version to install (default keeps Jenkins parity) |
+| `extra-args` | No | - | Extra arguments appended to the Hugo command (split on whitespace; quoted groups are not preserved) |
+| `extended` | No | `false` | Install extended Hugo binary; must be `true` or `false` |
+
+## Behavior
+
+- validates inputs and fails fast on invalid values
+- verifies `source` exists and is a directory
+- installs Hugo from GitHub releases (`https://github.com/gohugoio/hugo/releases/download`)
+- adds downloaded Hugo binary to `PATH`
+- runs `hugo --source <source>`
+- adds `--destination <destination>` when `destination` is set
+- appends `extra-args` when provided (split on whitespace with glob expansion disabled)
+
+## Example usage
+
+```yaml
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docs with pinned Hugo
+        uses: camunda/automation-platform-github-actions/docs-hugo-build@<commit-sha-or-version-tag>
+        with:
+          source: ./docs
+          destination: ./public
+          hugo-version: 0.54.0
+          extra-args: --minify --verbose
+          extended: false
+```
+
+## Notes
+
+- The default `hugo-version` is `0.54.0` for Jenkins behavior parity.
+- Override `hugo-version` only when migration requirements allow it.
+- This action does not publish artifacts and does not perform remote operations.
+- Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -21,7 +21,7 @@ The action is intentionally generic and repository-agnostic:
 | `source` | Yes | - | Path to the Hugo site/project directory |
 | `destination` | No | - | Optional Hugo output directory (`--destination`) |
 | `hugo-version` | No | `0.54.0` | Hugo version to install (default keeps Jenkins parity) |
-| `extra-args` | No | - | Extra arguments appended to the Hugo command (split on whitespace; quoted groups are not preserved) |
+| `extra-args` | No | - | Extra arguments appended to the Hugo command (split on whitespace; quoted groups are not preserved). `--source`, `--destination`, and `server` are rejected. |
 | `extended` | No | `false` | Install extended Hugo binary; must be `true` or `false` |
 
 ## Behavior
@@ -32,7 +32,7 @@ The action is intentionally generic and repository-agnostic:
 - adds downloaded Hugo binary to `PATH`
 - runs `hugo --source <source>`
 - adds `--destination <destination>` when `destination` is set
-- appends `extra-args` when provided (split on whitespace with glob expansion disabled)
+- appends `extra-args` when provided (split on whitespace with glob expansion disabled), but rejects `--source`, `--destination`, and `server`
 
 ## Example usage
 

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -59,4 +59,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
-- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `ruby`, and `python3`.
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, and `ruby`.

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -163,14 +163,44 @@ runs:
         })"
 
         archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
+        checksums_url="https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt"
 
         install_root="${RUNNER_TEMP:-$(mktemp -d)}/docs-hugo-build-${version}"
         bin_dir="$install_root/bin"
         archive_path="$install_root/$archive_name"
+        checksums_path="$install_root/hugo_${version}_checksums.txt"
 
         mkdir -p "$bin_dir"
 
-        curl -fsSL "$archive_url" -o "$archive_path"
+        if ! curl -fsSL --retry 3 --retry-delay 2 "$archive_url" -o "$archive_path"; then
+          echo "Failed to fetch Hugo archive from $archive_url" >&2
+          exit 1
+        fi
+
+        if ! curl -fsSL --retry 3 --retry-delay 2 "$checksums_url" -o "$checksums_path"; then
+          echo "Failed to fetch Hugo checksums from $checksums_url" >&2
+          exit 1
+        fi
+
+        checksum_line="$(grep -F "  $archive_name" "$checksums_path" | head -n 1 || true)"
+        if [[ -z "$checksum_line" ]]; then
+          echo "No checksum entry found for ${archive_name} in ${checksums_url}" >&2
+          exit 1
+        fi
+
+        (
+          cd "$install_root"
+          if command -v sha256sum >/dev/null 2>&1; then
+            printf '%s\n' "$checksum_line" | sha256sum -c -
+          elif command -v shasum >/dev/null 2>&1; then
+            printf '%s\n' "$checksum_line" | shasum -a 256 -c -
+          else
+            echo "sha256sum or shasum is required to verify Hugo archive checksum" >&2
+            exit 1
+          fi
+        )
+
+        rm -f "$checksums_path"
 
         tar -xzf "$archive_path" -C "$bin_dir" hugo
         rm -f "$archive_path"

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -63,6 +63,7 @@ runs:
       env:
         INPUT_HUGO_VERSION: ${{ inputs.hugo-version }}
         INPUT_EXTENDED: ${{ inputs.extended }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
@@ -100,7 +101,7 @@ runs:
           Darwin)
             case "$arch_name" in
               x86_64|amd64) preferred_suffixes=("darwin-universal" "darwin-amd64" "macOS-64bit") ;;
-              arm64|aarch64) preferred_suffixes=("darwin-universal" "darwin-arm64" "macOS-64bit") ;;
+              arm64|aarch64) preferred_suffixes=("darwin-universal" "darwin-arm64") ;;
               *)
                 echo "Unsupported runner architecture on Darwin: $arch_name" >&2
                 exit 1

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -89,8 +89,8 @@ runs:
         case "$os_name" in
           Linux)
             case "$arch_name" in
-              x86_64|amd64) preferred_suffixes=("Linux-64bit") ;;
-              arm64|aarch64) preferred_suffixes=("Linux-ARM64" "Linux-64bit") ;;
+              x86_64|amd64) preferred_suffixes=("linux-amd64" "Linux-64bit") ;;
+              arm64|aarch64) preferred_suffixes=("linux-arm64" "Linux-ARM64") ;;
               *)
                 echo "Unsupported runner architecture on Linux: $arch_name" >&2
                 exit 1
@@ -98,18 +98,40 @@ runs:
             esac
             ;;
           Darwin)
-            # Newer Hugo uses darwin-universal, older Hugo uses macOS-64bit.
-            preferred_suffixes=("darwin-universal" "macOS-64bit")
+            case "$arch_name" in
+              x86_64|amd64) preferred_suffixes=("darwin-universal" "darwin-amd64" "macOS-64bit") ;;
+              arm64|aarch64) preferred_suffixes=("darwin-universal" "darwin-arm64" "macOS-64bit") ;;
+              *)
+                echo "Unsupported runner architecture on Darwin: $arch_name" >&2
+                exit 1
+                ;;
+            esac
             ;;
         esac
 
+        if ! command -v ruby >/dev/null 2>&1; then
+          echo "ruby is required to parse GitHub release metadata" >&2
+          exit 1
+        fi
+
         release_api_url="https://api.github.com/repos/gohugoio/hugo/releases/tags/v${version}"
+        release_json="$(mktemp)"
+        curl_args=(-fsSL)
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+          curl_args+=(
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          )
+        fi
+
+        curl "${curl_args[@]}" "$release_api_url" -o "$release_json"
+
         archive_name="$({
           RELEASE_PREFIX="$release_prefix" \
           VERSION="$version" \
           PREFERRED_SUFFIXES="$(IFS=:; echo "${preferred_suffixes[*]}")" \
-          curl -fsSL "$release_api_url" | ruby -rjson -e '
-            payload = JSON.parse(STDIN.read)
+          ruby -rjson -e '
+            payload = JSON.parse(File.read(ARGV.fetch(0)))
             prefix = ENV.fetch("RELEASE_PREFIX")
             suffixes = ENV.fetch("PREFERRED_SUFFIXES").split(":")
             asset_names = payload.fetch("assets").map { |a| a.fetch("name") }
@@ -131,7 +153,7 @@ runs:
             end
 
             puts selected
-          '
+          ' "$release_json"
         })"
 
         archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -127,7 +127,7 @@ runs:
           )
         fi
 
-        if ! curl "${curl_args[@]}" "$release_api_url" -o "$release_json"; then
+        if ! curl "${curl_args[@]}" --retry 3 --retry-delay 2 "$release_api_url" -o "$release_json"; then
           echo "Failed to fetch Hugo release metadata from $release_api_url. Ensure tag v${version} exists and the workflow is not rate-limited." >&2
           exit 1
         fi
@@ -241,15 +241,7 @@ runs:
           exit 1
         fi
 
-        hugo_cmd=("$hugo_bin" --source "$source_dir")
-
-        if [[ -n "$destination_dir" ]]; then
-          if [[ "$destination_dir" == -* ]]; then
-            echo "destination must not start with '-'" >&2
-            exit 1
-          fi
-          hugo_cmd+=(--destination "$destination_dir")
-        fi
+        hugo_cmd=("$hugo_bin")
 
         if [[ -n "$extra_args" ]]; then
           # extra-args are split by shell words; quoted groups inside the string are not preserved.
@@ -257,7 +249,31 @@ runs:
           # shellcheck disable=SC2206
           extra_args_array=( $extra_args )
           set +f
+
+          for arg in "${extra_args_array[@]}"; do
+            case "$arg" in
+              --source|-s|--source=*|-s=*|--destination|-d|--destination=*|-d=*)
+                echo "extra-args must not override source or destination" >&2
+                exit 1
+                ;;
+              server)
+                echo "extra-args must not include Hugo subcommand 'server'" >&2
+                exit 1
+                ;;
+            esac
+          done
+
           hugo_cmd+=("${extra_args_array[@]}")
+        fi
+
+        hugo_cmd+=(--source "$source_dir")
+
+        if [[ -n "$destination_dir" ]]; then
+          if [[ "$destination_dir" == -* ]]; then
+            echo "destination must not start with '-'" >&2
+            exit 1
+          fi
+          hugo_cmd+=(--destination "$destination_dir")
         fi
 
         "${hugo_cmd[@]}"

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -59,6 +59,7 @@ runs:
         esac
 
     - name: Install Hugo
+      id: install
       shell: bash
       env:
         INPUT_HUGO_VERSION: ${{ inputs.hugo-version }}
@@ -117,6 +118,7 @@ runs:
 
         release_api_url="https://api.github.com/repos/gohugoio/hugo/releases/tags/v${version}"
         release_json="$(mktemp)"
+        trap 'rm -f "$release_json"' EXIT
         curl_args=(-fsSL)
         if [[ -n "${GITHUB_TOKEN:-}" ]]; then
           curl_args+=(
@@ -174,6 +176,10 @@ runs:
           printf '%s\n' "$bin_dir" >> "$GITHUB_PATH"
         fi
 
+        if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+          printf 'hugo_bin=%s\n' "$bin_dir/hugo" >> "$GITHUB_OUTPUT"
+        fi
+
         "$bin_dir/hugo" version
 
     - name: Build docs with Hugo
@@ -182,19 +188,26 @@ runs:
         INPUT_SOURCE: ${{ inputs.source }}
         INPUT_DESTINATION: ${{ inputs.destination }}
         INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
+        HUGO_BIN: ${{ steps.install.outputs.hugo_bin }}
       run: |
         set -euo pipefail
 
         source_dir="$INPUT_SOURCE"
         destination_dir="$INPUT_DESTINATION"
         extra_args="$INPUT_EXTRA_ARGS"
+        hugo_bin="$HUGO_BIN"
 
-        if ! command -v hugo >/dev/null 2>&1; then
-          echo "hugo is not available on PATH" >&2
+        if [[ -z "$hugo_bin" ]]; then
+          echo "HUGO_BIN output is empty; Install Hugo step did not provide a binary path" >&2
           exit 1
         fi
 
-        hugo_cmd=(hugo --source "$source_dir")
+        if [[ ! -x "$hugo_bin" ]]; then
+          echo "Hugo binary is not executable: $hugo_bin" >&2
+          exit 1
+        fi
+
+        hugo_cmd=("$hugo_bin" --source "$source_dir")
 
         if [[ -n "$destination_dir" ]]; then
           if [[ "$destination_dir" == -* ]]; then

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -127,7 +127,10 @@ runs:
           )
         fi
 
-        curl "${curl_args[@]}" "$release_api_url" -o "$release_json"
+        if ! curl "${curl_args[@]}" "$release_api_url" -o "$release_json"; then
+          echo "Failed to fetch Hugo release metadata from $release_api_url. Ensure tag v${version} exists and the workflow is not rate-limited." >&2
+          exit 1
+        fi
 
         archive_name="$({
           RELEASE_PREFIX="$release_prefix" \
@@ -170,6 +173,7 @@ runs:
         curl -fsSL "$archive_url" -o "$archive_path"
 
         tar -xzf "$archive_path" -C "$bin_dir" hugo
+        rm -f "$archive_path"
         chmod +x "$bin_dir/hugo"
 
         if [[ -n "${GITHUB_PATH:-}" ]]; then

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -1,0 +1,193 @@
+name: "Docs Hugo build"
+description: "Build Hugo docs with a pinned Hugo version (default 0.54.0)"
+inputs:
+  source:
+    description: "Path to the Hugo site/project directory"
+    required: true
+  destination:
+    description: "Optional output directory passed to Hugo via --destination"
+    required: false
+  hugo-version:
+    description: "Hugo version to install"
+    required: false
+    default: "0.54.0"
+  extra-args:
+    description: "Extra arguments appended to the Hugo command"
+    required: false
+  extended:
+    description: "Install Hugo extended build (true or false)"
+    required: false
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_DESTINATION: ${{ inputs.destination }}
+        INPUT_HUGO_VERSION: ${{ inputs.hugo-version }}
+        INPUT_EXTENDED: ${{ inputs.extended }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$INPUT_SOURCE" ]]; then
+          echo "Missing required input: source" >&2
+          exit 1
+        fi
+        if [[ ! -d "$INPUT_SOURCE" ]]; then
+          echo "source directory does not exist: $INPUT_SOURCE" >&2
+          exit 1
+        fi
+
+        if [[ -n "$INPUT_DESTINATION" && "$INPUT_DESTINATION" == -* ]]; then
+          echo "destination must not start with '-'" >&2
+          exit 1
+        fi
+
+        if [[ ! "$INPUT_HUGO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid hugo-version. Expected semantic version like 0.54.0" >&2
+          exit 1
+        fi
+
+        case "$INPUT_EXTENDED" in
+          true|false) ;;
+          *)
+            echo "Invalid extended value. Allowed values: true, false" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Install Hugo
+      shell: bash
+      env:
+        INPUT_HUGO_VERSION: ${{ inputs.hugo-version }}
+        INPUT_EXTENDED: ${{ inputs.extended }}
+      run: |
+        set -euo pipefail
+
+        version="$INPUT_HUGO_VERSION"
+        extended="$INPUT_EXTENDED"
+
+        os_name="$(uname -s)"
+        arch_name="$(uname -m)"
+
+        case "$os_name" in
+          Linux) ;;
+          Darwin) ;;
+          *)
+            echo "Unsupported runner OS: $os_name" >&2
+            exit 1
+            ;;
+        esac
+
+        release_prefix="hugo"
+        if [[ "$extended" == "true" ]]; then
+          release_prefix="hugo_extended"
+        fi
+
+        case "$os_name" in
+          Linux)
+            case "$arch_name" in
+              x86_64|amd64) preferred_suffixes=("Linux-64bit") ;;
+              arm64|aarch64) preferred_suffixes=("Linux-ARM64" "Linux-64bit") ;;
+              *)
+                echo "Unsupported runner architecture on Linux: $arch_name" >&2
+                exit 1
+                ;;
+            esac
+            ;;
+          Darwin)
+            # Newer Hugo uses darwin-universal, older Hugo uses macOS-64bit.
+            preferred_suffixes=("darwin-universal" "macOS-64bit")
+            ;;
+        esac
+
+        release_api_url="https://api.github.com/repos/gohugoio/hugo/releases/tags/v${version}"
+        archive_name="$({
+          RELEASE_PREFIX="$release_prefix" \
+          VERSION="$version" \
+          PREFERRED_SUFFIXES="$(IFS=:; echo "${preferred_suffixes[*]}")" \
+          curl -fsSL "$release_api_url" | ruby -rjson -e '
+            payload = JSON.parse(STDIN.read)
+            prefix = ENV.fetch("RELEASE_PREFIX")
+            suffixes = ENV.fetch("PREFERRED_SUFFIXES").split(":")
+            asset_names = payload.fetch("assets").map { |a| a.fetch("name") }
+
+            selected = nil
+            suffixes.each do |suffix|
+              candidate = asset_names.find { |n| n == "#{prefix}_#{ENV.fetch("VERSION")}_#{suffix}.tar.gz" }
+              if candidate
+                selected = candidate
+                break
+              end
+            end
+
+            if selected.nil?
+              STDERR.puts "No matching Hugo archive found for version #{ENV.fetch("VERSION")} with prefix #{prefix}"
+              STDERR.puts "Available archives:"
+              asset_names.grep(/\.tar\.gz\z/).each { |n| STDERR.puts "  - #{n}" }
+              exit 1
+            end
+
+            puts selected
+          '
+        })"
+
+        archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
+
+        install_root="${RUNNER_TEMP:-$(mktemp -d)}/docs-hugo-build-${version}"
+        bin_dir="$install_root/bin"
+        archive_path="$install_root/$archive_name"
+
+        mkdir -p "$bin_dir"
+
+        curl -fsSL "$archive_url" -o "$archive_path"
+
+        tar -xzf "$archive_path" -C "$bin_dir" hugo
+        chmod +x "$bin_dir/hugo"
+
+        if [[ -n "${GITHUB_PATH:-}" ]]; then
+          printf '%s\n' "$bin_dir" >> "$GITHUB_PATH"
+        fi
+
+        "$bin_dir/hugo" version
+
+    - name: Build docs with Hugo
+      shell: bash
+      env:
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_DESTINATION: ${{ inputs.destination }}
+        INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        set -euo pipefail
+
+        source_dir="$INPUT_SOURCE"
+        destination_dir="$INPUT_DESTINATION"
+        extra_args="$INPUT_EXTRA_ARGS"
+
+        if ! command -v hugo >/dev/null 2>&1; then
+          echo "hugo is not available on PATH" >&2
+          exit 1
+        fi
+
+        hugo_cmd=(hugo --source "$source_dir")
+
+        if [[ -n "$destination_dir" ]]; then
+          if [[ "$destination_dir" == -* ]]; then
+            echo "destination must not start with '-'" >&2
+            exit 1
+          fi
+          hugo_cmd+=(--destination "$destination_dir")
+        fi
+
+        if [[ -n "$extra_args" ]]; then
+          # extra-args are split by shell words; quoted groups inside the string are not preserved.
+          set -f
+          # shellcheck disable=SC2206
+          extra_args_array=( $extra_args )
+          set +f
+          hugo_cmd+=("${extra_args_array[@]}")
+        fi
+
+        "${hugo_cmd[@]}"

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -101,8 +101,8 @@ runs:
             ;;
           Darwin)
             case "$arch_name" in
-              x86_64|amd64) preferred_suffixes=("darwin-universal" "darwin-amd64" "macOS-64bit") ;;
-              arm64|aarch64) preferred_suffixes=("darwin-universal" "darwin-arm64") ;;
+              x86_64|amd64) preferred_suffixes=("darwin-universal" "darwin-amd64" "Darwin-64bit" "macOS-64bit") ;;
+              arm64|aarch64) preferred_suffixes=("darwin-universal" "darwin-arm64" "Darwin-ARM64") ;;
               *)
                 echo "Unsupported runner architecture on Darwin: $arch_name" >&2
                 exit 1


### PR DESCRIPTION
## Description

Adds a reusable `docs-hugo-build` composite action for the docs release migration foundation tracked in camunda/camunda-bpm-platform-maintenance#3005.

The action installs a pinned Hugo version and builds a provided Hugo source directory. The default Hugo version is `0.54.0` to preserve Jenkins parity.

## What changed

* Added `docs-hugo-build/action.yml`
* Added `docs-hugo-build/README.md`
* Added inputs for:

  * `source`
  * `destination`
  * `hugo-version`
  * `extra-args`
  * `extended`
* Added input validation and fail-fast behavior
* Added README usage and non-goals
* Architecture-aware Hugo archive suffix selection for Linux (amd64/arm64) and Darwin (amd64/arm64), including legacy `Darwin-64bit` naming for older releases (e.g. `0.54.0`) on x86_64
* Explicit Ruby availability check before release metadata parsing
* `GITHUB_TOKEN` explicitly injected via `env` for authenticated GitHub API calls
* Retry logic (`--retry 3`) on all `curl` calls (release metadata, archive, checksums)
* Hugo archive checksum verification using Hugo's published checksums file (`sha256sum` with `shasum -a 256` fallback)
* Temp file cleanup via `trap` for release JSON and explicit `rm` for archive and checksums after use
* Hugo binary path exposed as install-step output and invoked directly in the build step (no reliance on `GITHUB_PATH`)
* `extra-args` hardened: `--source`, `-s`, `--destination`, `-d`, and the `server` subcommand are rejected; validated `--source`/`--destination` are always appended after `extra-args`

## Safety / non-goals

This action intentionally does not include:

* rsync
* SSH
* Vault
* deployment
* Jenkins cleanup
* Camunda-internal hardcoded paths or hosts

## Validation

Performed locally:

* YAML parse for `docs-hugo-build/action.yml`
* `bash -n` over all composite action `run` blocks
* Minimal Hugo `0.54.0` smoke build against a temporary Hugo site
* Negative validation for rejected `extra-args` values

No deploy, SSH, rsync, or remote operations were executed.

## Related

 - https://github.com/camunda/camunda-bpm-platform-maintenance/issues/3005