### PR TITLE
ci(docs): add reusable docs link-checker action

### DIFF
--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -15,7 +15,7 @@ Read-only parity search paths:
 Findings:
 
 - `jenkins-job-dsl-seed-jobs/src/main/groovy/util/ScriptResources.groovy` defines `DOWNLOAD_PYLINKVALIDATOR` and `linkCheckerScript`.
-- Jenkins installs `python34` + `python34-pip`, then installs `soupsieve==2.2.1`, `beautifulsoup4==4.12.3`, and `pylinkvalidator` via `pip3.4`.
+- Jenkins installs `python34` + `python34-pip`, then installs `soupsieve==2.2.1`, `beautifulsoup4==4.12.3`, and `pyLinkValidator` (imported as `pylinkvalidator`) via `pip3.4`.
 - Jenkins then runs `python3.4 infra-core/cmd/link-checker/link-checker.py -u http://localhost:1313 -i <ignoreRegex>` after starting `hugo server`.
 - `infra-core/cmd/link-checker/link-checker.py` applies `-i/--ignore` as a Python regex using `re.match` against each broken URL path.
 - This action keeps parity at behavior level for link validation (HTTP crawl + failing on errors) while using a reusable deterministic setup: pinned `pyLinkValidator` in an isolated virtual environment.

--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -24,14 +24,15 @@ Findings:
 
 | Input | Required | Default | Description |
 | --- | --- | --- | --- |
-| `source` | Yes | - | Path to built docs/output directory to check |
+| `source` | Yes (unless `base-url` is set) | - | Path to built docs/output directory to check |
 | `base-url` | No | - | Optional `http(s)` URL to check instead of serving `source` |
 | `ignore-regex` | No | - | Python regex matched via `re.match` against each broken URL path |
 | `pylinkvalidator-version` | No | `0.3` | Version of `pyLinkValidator` installed via pip |
 
 ## Behavior
 
-- fails fast if `source` does not exist
+- fails fast if neither `source` nor `base-url` is provided
+- validates that `source` exists when local serving mode is used
 - validates `base-url` format when provided
 - creates an isolated virtual environment and installs pinned `pyLinkValidator`
 - runs a Python wrapper based on `pylinkvalidator.api.crawl(<target-url>)`

--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -8,9 +8,9 @@ This action is part of the docs release migration Phase 1 shared foundation for 
 
 Read-only parity search paths:
 
-- `/Users/oleksii/IdeaProjects/jenkins-job-dsl-seed-jobs`
-- `/Users/oleksii/IdeaProjects/cambpm-jenkins-shared-library`
-- `/Users/oleksii/IdeaProjects/infra-core`
+- `jenkins-job-dsl-seed-jobs`
+- `cambpm-jenkins-shared-library`
+- `infra-core`
 
 Findings:
 

--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -1,0 +1,74 @@
+# docs-link-checker
+
+Reusable composite action to run docs link checking in a deterministic way with `pyLinkValidator`.
+
+This action is part of the docs release migration Phase 1 shared foundation for `camunda/camunda-bpm-platform-maintenance#3005` and focuses only on link checking.
+
+## Jenkins parity notes
+
+Read-only parity search paths:
+
+- `/Users/oleksii/IdeaProjects/jenkins-job-dsl-seed-jobs`
+- `/Users/oleksii/IdeaProjects/cambpm-jenkins-shared-library`
+- `/Users/oleksii/IdeaProjects/infra-core`
+
+Findings:
+
+- `jenkins-job-dsl-seed-jobs/src/main/groovy/util/ScriptResources.groovy` defines `DOWNLOAD_PYLINKVALIDATOR` and `linkCheckerScript`.
+- Jenkins installs `python34` + `python34-pip`, then installs `soupsieve==2.2.1`, `beautifulsoup4==4.12.3`, and `pylinkvalidator` via `pip3.4`.
+- Jenkins then runs `python3.4 infra-core/cmd/link-checker/link-checker.py -u http://localhost:1313 -i <ignoreRegex>` after starting `hugo server`.
+- `infra-core/cmd/link-checker/link-checker.py` applies `-i/--ignore` as a Python regex using `re.match` against each broken URL path.
+- This action keeps parity at behavior level for link validation (HTTP crawl + failing on errors) while using a reusable deterministic setup: pinned `pyLinkValidator` in an isolated virtual environment.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `source` | Yes | - | Path to built docs/output directory to check |
+| `base-url` | No | - | Optional `http(s)` URL to check instead of serving `source` |
+| `ignore-regex` | No | - | Python regex matched via `re.match` against each broken URL path |
+| `pylinkvalidator-version` | No | `0.3` | Version of `pyLinkValidator` installed via pip |
+
+## Behavior
+
+- fails fast if `source` does not exist
+- validates `base-url` format when provided
+- creates an isolated virtual environment and installs pinned `pyLinkValidator`
+- runs a Python wrapper based on `pylinkvalidator.api.crawl(<target-url>)`
+- applies `ignore-regex` using `re.match(ignore_regex, broken_path)` (Jenkins wrapper semantics)
+- exits non-zero when broken links are detected
+
+`ignore-regex` matches broken URL paths (for example: `^/(cawemo|test)`).
+
+## Example usage
+
+```yaml
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check built docs links
+        uses: camunda/automation-platform-github-actions/docs-link-checker@<commit-sha-or-version-tag>
+        with:
+          source: ./public
+          ignore-regex: ^/missing\.html$
+```
+
+## Validation behavior
+
+The action returns a non-zero exit code if:
+
+- required inputs are invalid;
+- tool installation fails;
+- the link checker finds errors.
+
+## Non-goals
+
+- no Hugo build
+- no rsync
+- no SSH
+- no Vault
+- no deployment
+- no Jenkins cleanup

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -1,0 +1,175 @@
+name: "Docs link checker"
+description: "Run deterministic docs link checks with pyLinkValidator"
+inputs:
+  source:
+    description: "Path to built docs/output directory to check"
+    required: true
+  base-url:
+    description: "Optional base URL to check instead of serving the local source directory"
+    required: false
+  ignore-regex:
+    description: "Optional Python regex matched via re.match against each broken URL path"
+    required: false
+  pylinkvalidator-version:
+    description: "pyLinkValidator version to install"
+    required: false
+    default: "0.3"
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_BASE_URL: ${{ inputs.base-url }}
+        INPUT_IGNORE_REGEX: ${{ inputs.ignore-regex }}
+        INPUT_PYLINKVALIDATOR_VERSION: ${{ inputs.pylinkvalidator-version }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$INPUT_SOURCE" ]]; then
+          echo "Missing required input: source" >&2
+          exit 1
+        fi
+        if [[ ! -d "$INPUT_SOURCE" ]]; then
+          echo "source directory does not exist: $INPUT_SOURCE" >&2
+          exit 1
+        fi
+
+        if [[ -n "$INPUT_BASE_URL" && ! "$INPUT_BASE_URL" =~ ^https?://[^[:space:]]+$ ]]; then
+          echo "Invalid base-url. Expected http(s)://..." >&2
+          exit 1
+        fi
+
+        if [[ ! "$INPUT_PYLINKVALIDATOR_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+          echo "Invalid pylinkvalidator-version. Expected numeric version such as 0.3" >&2
+          exit 1
+        fi
+
+        if [[ -n "$INPUT_IGNORE_REGEX" ]]; then
+          IGNORE_REGEX="$INPUT_IGNORE_REGEX" \
+            python3 -c 'import os,re; re.compile(os.environ["IGNORE_REGEX"])'
+        fi
+
+    - name: Install pyLinkValidator
+      id: install
+      shell: bash
+      env:
+        INPUT_PYLINKVALIDATOR_VERSION: ${{ inputs.pylinkvalidator-version }}
+      run: |
+        set -euo pipefail
+
+        python_bin="python3"
+        if ! command -v "$python_bin" >/dev/null 2>&1; then
+          echo "python3 is required but not available on PATH" >&2
+          exit 1
+        fi
+
+        venv_dir="${RUNNER_TEMP:-$(mktemp -d)}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}"
+        "$python_bin" -m venv "$venv_dir"
+        "$venv_dir/bin/python" -m pip --disable-pip-version-check --no-input install "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
+
+        checker_bin="$venv_dir/bin/pylinkvalidate.py"
+        if [[ ! -x "$checker_bin" ]]; then
+          echo "pylinkvalidate.py was not installed as expected" >&2
+          exit 1
+        fi
+
+        "$checker_bin" --version
+
+        {
+          echo "venv_dir=$venv_dir"
+          echo "checker_python=$venv_dir/bin/python"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Run link check
+      shell: bash
+      env:
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_BASE_URL: ${{ inputs.base-url }}
+        INPUT_IGNORE_REGEX: ${{ inputs.ignore-regex }}
+        CHECKER_PYTHON: ${{ steps.install.outputs.checker_python }}
+      run: |
+        set -euo pipefail
+
+        source_dir="$INPUT_SOURCE"
+        base_url="$INPUT_BASE_URL"
+        ignore_regex="$INPUT_IGNORE_REGEX"
+
+        if [[ ! -x "$CHECKER_PYTHON" ]]; then
+          echo "checker python is not executable: $CHECKER_PYTHON" >&2
+          exit 1
+        fi
+
+        if [[ -n "$base_url" ]]; then
+          target_url="$base_url"
+        else
+          port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+
+          python3 -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >/tmp/docs-link-checker-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" >/dev/null 2>&1 || true' EXIT
+          sleep 1
+          target_url="http://127.0.0.1:${port}"
+        fi
+
+        TARGET_URL="$target_url" IGNORE_REGEX="$ignore_regex" "$CHECKER_PYTHON" - <<'PY'
+        import os
+        import re
+        import sys
+        from urllib.parse import urlparse
+
+        from pylinkvalidator.api import crawl
+
+        target_url = os.environ["TARGET_URL"]
+        ignore_regex = os.environ.get("IGNORE_REGEX", "")
+
+        compiled_regex = re.compile(ignore_regex) if ignore_regex else None
+        crawled_site = crawl(target_url)
+
+        def broken_path(page_key):
+            path = getattr(page_key, "path", "")
+            if path:
+                return path
+            parsed = urlparse(str(page_key))
+            return parsed.path or str(page_key)
+
+        ignored = []
+        non_ignored = []
+        for page_key, page_item in crawled_site.error_pages.items():
+            path = broken_path(page_key)
+            if compiled_regex and compiled_regex.match(path):
+                ignored.append((page_key, page_item, path))
+            else:
+                non_ignored.append((page_key, page_item, path))
+
+        print("Checked {} links, {} broken, {} ignored, {} failing.".format(
+            len(crawled_site.pages.items()),
+            len(crawled_site.error_pages.items()),
+            len(ignored),
+            len(non_ignored),
+        ))
+
+        if ignored:
+            print("Ignored broken links (matched ignore-regex):")
+            for page_key, _page_item, path in ignored:
+                print("  - {} (path: {})".format(page_key, path))
+
+        if non_ignored:
+            print("Failing broken links:")
+            for page_key, page_item, _path in non_ignored:
+                print(page_item)
+                print("  Linked from:")
+                page_obj = crawled_site.pages.get(page_key)
+                source_descriptions = []
+                if page_obj is not None:
+                    source_descriptions = [
+                        source.origin.scheme + "://" + source.origin.netloc + source.origin.path + "(" + source.origin_str + ")"
+                        for source in page_obj.sources
+                    ]
+                for source_description in sorted(set(source_descriptions)):
+                    print(source_description)
+            sys.exit(1)
+
+        sys.exit(0)
+        PY

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -2,8 +2,8 @@ name: "Docs link checker"
 description: "Run deterministic docs link checks with pyLinkValidator"
 inputs:
   source:
-    description: "Path to built docs/output directory to check"
-    required: true
+    description: "Path to built docs/output directory to check (required when base-url is not provided)"
+    required: false
   base-url:
     description: "Optional base URL to check instead of serving the local source directory"
     required: false
@@ -27,11 +27,11 @@ runs:
       run: |
         set -euo pipefail
 
-        if [[ -z "$INPUT_SOURCE" ]]; then
-          echo "Missing required input: source" >&2
+        if [[ -z "$INPUT_SOURCE" && -z "$INPUT_BASE_URL" ]]; then
+          echo "Missing required input: source (or provide base-url)" >&2
           exit 1
         fi
-        if [[ ! -d "$INPUT_SOURCE" ]]; then
+        if [[ -n "$INPUT_SOURCE" && ! -d "$INPUT_SOURCE" ]]; then
           echo "source directory does not exist: $INPUT_SOURCE" >&2
           exit 1
         fi

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -31,7 +31,7 @@ runs:
           echo "Missing required input: source (or provide base-url)" >&2
           exit 1
         fi
-        if [[ -n "$INPUT_SOURCE" && ! -d "$INPUT_SOURCE" ]]; then
+        if [[ -z "$INPUT_BASE_URL" && ! -d "$INPUT_SOURCE" ]]; then
           echo "source directory does not exist: $INPUT_SOURCE" >&2
           exit 1
         fi
@@ -133,10 +133,10 @@ runs:
         if [[ -n "$base_url" ]]; then
           target_url="$base_url"
         else
-          port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+          port="$("$CHECKER_PYTHON" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
           http_log="${RUNNER_TEMP:-/tmp}/docs-link-checker-http-${port}.log"
 
-          python3 -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >"$http_log" 2>&1 &
+          "$CHECKER_PYTHON" -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >"$http_log" 2>&1 &
           server_pid=$!
           trap 'kill "$server_pid" >/dev/null 2>&1 || true' EXIT
           target_url="http://127.0.0.1:${port}"
@@ -150,7 +150,7 @@ runs:
               fi
               exit 1
             fi
-            if TARGET_URL="$target_url" python3 - <<'PY'
+            if TARGET_URL="$target_url" "$CHECKER_PYTHON" - <<'PY'
         import os
         import urllib.request
         import urllib.error

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -81,7 +81,7 @@ runs:
           exit 1
         fi
 
-        venv_dir="${RUNNER_TEMP:-$(mktemp -d)}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}"
+        venv_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}-XXXXXXXX")"
         "$python_bin" -m venv "$venv_dir"
 
         if [[ -f "$venv_dir/bin/python" ]]; then
@@ -93,7 +93,7 @@ runs:
           exit 1
         fi
 
-        "$checker_python" -m pip --disable-pip-version-check --no-input install "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
+        "$checker_python" -m pip --disable-pip-version-check --no-input install "soupsieve==2.2.1" "beautifulsoup4==4.12.3" "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
 
         "$checker_python" - <<'PY'
         from pylinkvalidator.api import crawl

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -51,8 +51,20 @@ runs:
             echo "python3 is required to validate ignore-regex but is not available on PATH" >&2
             exit 1
           fi
-          IGNORE_REGEX="$INPUT_IGNORE_REGEX" \
-            python3 -c 'import os,re; re.compile(os.environ["IGNORE_REGEX"])'
+          if ! IGNORE_REGEX="$INPUT_IGNORE_REGEX" python3 - <<'PY'
+        import os
+        import re
+        import sys
+
+        try:
+            re.compile(os.environ["IGNORE_REGEX"])
+        except re.error as exc:
+            print(f"invalid ignore-regex: {exc}", file=sys.stderr)
+            raise SystemExit(1)
+        PY
+          then
+            exit 1
+          fi
         fi
 
     - name: Install pyLinkValidator
@@ -71,9 +83,19 @@ runs:
 
         venv_dir="${RUNNER_TEMP:-$(mktemp -d)}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}"
         "$python_bin" -m venv "$venv_dir"
-        "$venv_dir/bin/python" -m pip --disable-pip-version-check --no-input install "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
 
-        "$venv_dir/bin/python" - <<'PY'
+        if [[ -f "$venv_dir/bin/python" ]]; then
+          checker_python="$venv_dir/bin/python"
+        elif [[ -f "$venv_dir/Scripts/python.exe" ]]; then
+          checker_python="$venv_dir/Scripts/python.exe"
+        else
+          echo "Unable to locate virtualenv Python interpreter under: $venv_dir" >&2
+          exit 1
+        fi
+
+        "$checker_python" -m pip --disable-pip-version-check --no-input install "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
+
+        "$checker_python" - <<'PY'
         from pylinkvalidator.api import crawl
 
         print("pylinkvalidator API import OK")
@@ -81,7 +103,7 @@ runs:
 
         {
           echo "venv_dir=$venv_dir"
-          echo "checker_python=$venv_dir/bin/python"
+          echo "checker_python=$checker_python"
         } >> "$GITHUB_OUTPUT"
 
     - name: Run link check
@@ -98,8 +120,13 @@ runs:
         base_url="$INPUT_BASE_URL"
         ignore_regex="$INPUT_IGNORE_REGEX"
 
-        if [[ ! -x "$CHECKER_PYTHON" ]]; then
-          echo "checker python is not executable: $CHECKER_PYTHON" >&2
+        if [[ ! -f "$CHECKER_PYTHON" ]]; then
+          echo "checker python does not exist: $CHECKER_PYTHON" >&2
+          exit 1
+        fi
+        if ! checker_python_invocation="$("$CHECKER_PYTHON" -c 'import sys; print(sys.executable)' 2>&1)"; then
+          echo "checker python could not be invoked: $CHECKER_PYTHON" >&2
+          echo "$checker_python_invocation" >&2
           exit 1
         fi
 
@@ -112,8 +139,43 @@ runs:
           python3 -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >"$http_log" 2>&1 &
           server_pid=$!
           trap 'kill "$server_pid" >/dev/null 2>&1 || true' EXIT
-          sleep 1
           target_url="http://127.0.0.1:${port}"
+
+          server_ready=0
+          for ((_attempt=1; _attempt<=10; _attempt++)); do
+            if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+              echo "local HTTP server exited before becoming ready; log: $http_log" >&2
+              if [[ -f "$http_log" ]]; then
+                cat "$http_log" >&2
+              fi
+              exit 1
+            fi
+            if TARGET_URL="$target_url" python3 - <<'PY'
+        import os
+        import urllib.request
+        import urllib.error
+
+        try:
+            with urllib.request.urlopen(os.environ["TARGET_URL"], timeout=1) as response:
+                if response.status >= 400:
+                    raise SystemExit(1)
+        except (urllib.error.URLError, TimeoutError, OSError):
+            raise SystemExit(1)
+        PY
+            then
+              server_ready=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [[ "$server_ready" -ne 1 ]]; then
+            echo "local HTTP server did not become ready in time; log: $http_log" >&2
+            if [[ -f "$http_log" ]]; then
+              cat "$http_log" >&2
+            fi
+            exit 1
+          fi
         fi
 
         TARGET_URL="$target_url" IGNORE_REGEX="$ignore_regex" "$CHECKER_PYTHON" - <<'PY'

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -47,6 +47,10 @@ runs:
         fi
 
         if [[ -n "$INPUT_IGNORE_REGEX" ]]; then
+          if ! command -v python3 >/dev/null 2>&1; then
+            echo "python3 is required to validate ignore-regex but is not available on PATH" >&2
+            exit 1
+          fi
           IGNORE_REGEX="$INPUT_IGNORE_REGEX" \
             python3 -c 'import os,re; re.compile(os.environ["IGNORE_REGEX"])'
         fi
@@ -69,13 +73,11 @@ runs:
         "$python_bin" -m venv "$venv_dir"
         "$venv_dir/bin/python" -m pip --disable-pip-version-check --no-input install "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
 
-        checker_bin="$venv_dir/bin/pylinkvalidate.py"
-        if [[ ! -x "$checker_bin" ]]; then
-          echo "pylinkvalidate.py was not installed as expected" >&2
-          exit 1
-        fi
+        "$venv_dir/bin/python" - <<'PY'
+        from pylinkvalidator.api import crawl
 
-        "$checker_bin" --version
+        print("pylinkvalidator API import OK")
+        PY
 
         {
           echo "venv_dir=$venv_dir"
@@ -105,8 +107,9 @@ runs:
           target_url="$base_url"
         else
           port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+          http_log="${RUNNER_TEMP:-/tmp}/docs-link-checker-http-${port}.log"
 
-          python3 -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >/tmp/docs-link-checker-http.log 2>&1 &
+          python3 -m http.server "$port" --bind 127.0.0.1 --directory "$source_dir" >"$http_log" 2>&1 &
           server_pid=$!
           trap 'kill "$server_pid" >/dev/null 2>&1 || true' EXIT
           sleep 1


### PR DESCRIPTION
## Description

Adds a reusable `docs-link-checker` composite action for the docs release migration foundation tracked in camunda/camunda-bpm-platform-maintenance#3005.

The action provides Jenkins-like link-checking behavior using `pyLinkValidator` in an isolated virtual environment. It serves a local built docs directory when no `base-url` is provided and applies `ignore-regex` using the same semantics as the Jenkins wrapper: Python `re.match` against each broken URL path.

## What changed

* Added `docs-link-checker/action.yml`
* Added `docs-link-checker/README.md`
* Added inputs for:

  * `source`
  * `base-url`
  * `ignore-regex`
  * `pylinkvalidator-version`
* Added validation and fail-fast behavior
* Added local HTTP serving for built docs output
* Added Python wrapper around `pylinkvalidator.api.crawl`
* Added Jenkins parity notes and usage documentation

## Safety / non-goals

This action intentionally does not include:

* Hugo build
* rsync
* SSH
* Vault
* deployment
* Jenkins cleanup

## Validation

Performed locally:

* YAML parse for `docs-link-checker/action.yml`
* `bash -n` over all composite action `run` blocks
* Smoke test with a broken link and no `ignore-regex`: failed as expected
* Smoke test with the same broken link ignored by `ignore-regex`: passed as expected

No deploy, SSH, rsync, Vault, or remote operations were executed.

## Related

 - https://github.com/camunda/camunda-bpm-platform-maintenance/issues/3005
