### PR TITLE
ci(docs): harden reusable docs actions for runner portability

### DIFF
--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -60,4 +60,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
-- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `grep`, and either `sha256sum` or `shasum`.
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, and either `sha256sum` or `shasum`.

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -59,4 +59,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
-- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `ruby`, and either `sha256sum` or `shasum`.
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `node`, and either `sha256sum` or `shasum`.

--- a/docs-hugo-build/README.md
+++ b/docs-hugo-build/README.md
@@ -29,6 +29,7 @@ The action is intentionally generic and repository-agnostic:
 - validates inputs and fails fast on invalid values
 - verifies `source` exists and is a directory
 - installs Hugo from GitHub releases (`https://github.com/gohugoio/hugo/releases/download`)
+- selects the matching Hugo archive from the published checksums file using preferred OS/architecture suffix order
 - adds downloaded Hugo binary to `PATH`
 - runs `hugo --source <source>`
 - adds `--destination <destination>` when `destination` is set
@@ -59,4 +60,4 @@ jobs:
 - Override `hugo-version` only when migration requirements allow it.
 - This action does not publish artifacts and does not perform remote operations.
 - Release workflows should pin this action to a commit SHA or version tag (avoid `@main`).
-- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `node`, and either `sha256sum` or `shasum`.
+- The runner is expected to provide standard tools used by the action: `bash`, `curl`, `tar`, `grep`, and either `sha256sum` or `shasum`.

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -111,8 +111,8 @@ runs:
             ;;
         esac
 
-        if ! command -v ruby >/dev/null 2>&1; then
-          echo "ruby is required to parse GitHub release metadata" >&2
+        if ! command -v node >/dev/null 2>&1; then
+          echo "node is required to parse GitHub release metadata" >&2
           exit 1
         fi
 
@@ -136,32 +136,37 @@ runs:
           RELEASE_PREFIX="$release_prefix" \
           VERSION="$version" \
           PREFERRED_SUFFIXES="$(IFS=:; echo "${preferred_suffixes[*]}")" \
-          ruby -rjson -e '
-            payload = JSON.parse(File.read(ARGV.fetch(0)))
-            prefix = ENV.fetch("RELEASE_PREFIX")
-            suffixes = ENV.fetch("PREFERRED_SUFFIXES").split(":")
-            asset_names = payload.fetch("assets").map { |a| a.fetch("name") }
+          node -e '
+            const fs = require("fs");
+            const releaseJsonPath = process.argv[1];
+            const payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
+            const prefix = process.env.RELEASE_PREFIX;
+            const version = process.env.VERSION;
+            const suffixes = process.env.PREFERRED_SUFFIXES.split(":");
+            const assetNames = payload.assets.map((asset) => asset.name);
 
-            selected = nil
-            suffixes.each do |suffix|
-              candidate = asset_names.find { |n| n == "#{prefix}_#{ENV.fetch("VERSION")}_#{suffix}.tar.gz" }
-              if candidate
-                selected = candidate
-                break
-              end
-            end
+            let selected = null;
+            for (const suffix of suffixes) {
+              const candidate = `${prefix}_${version}_${suffix}.tar.gz`;
+              if (assetNames.includes(candidate)) {
+                selected = candidate;
+                break;
+              }
+            }
 
-            if selected.nil?
-              STDERR.puts "No matching Hugo archive found for version #{ENV.fetch("VERSION")} with prefix #{prefix}"
-              STDERR.puts "Available archives:"
-              asset_names.grep(/\.tar\.gz\z/).each { |n| STDERR.puts "  - #{n}" }
-              exit 1
-            end
+            if (!selected) {
+              console.error(`No matching Hugo archive found for version ${version}`);
+              console.error(`Selected prefix: ${prefix}`);
+              console.error("Available .tar.gz archives:");
+              for (const name of assetNames.filter((name) => name.endsWith(".tar.gz"))) {
+                console.error(`  - ${name}`);
+              }
+              process.exit(1);
+            }
 
-            puts selected
+            console.log(selected);
           ' "$release_json"
         })"
-
         archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
         checksums_url="https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt"
 

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -144,7 +144,14 @@ runs:
               console.error("Missing RELEASE_JSON_PATH");
               process.exit(1);
             }
-            const payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
+            let payload;
+            try {
+              payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
+            } catch (err) {
+              const message = err && err.message ? err.message : String(err);
+              console.error(`Failed to parse release metadata JSON at ${releaseJsonPath}: ${message}`);
+              process.exit(1);
+            }
             const prefix = process.env.RELEASE_PREFIX;
             const version = process.env.VERSION;
             const preferredSuffixes = process.env.PREFERRED_SUFFIXES;

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -147,7 +147,26 @@ runs:
             const payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
             const prefix = process.env.RELEASE_PREFIX;
             const version = process.env.VERSION;
-            const suffixes = process.env.PREFERRED_SUFFIXES.split(":");
+            const preferredSuffixes = process.env.PREFERRED_SUFFIXES;
+
+            if (!prefix) {
+              console.error("Missing RELEASE_PREFIX");
+              process.exit(1);
+            }
+            if (!version) {
+              console.error("Missing VERSION");
+              process.exit(1);
+            }
+            if (!preferredSuffixes) {
+              console.error("Missing PREFERRED_SUFFIXES");
+              process.exit(1);
+            }
+            if (!payload || !Array.isArray(payload.assets)) {
+              console.error("Invalid release metadata: missing assets array");
+              process.exit(1);
+            }
+
+            const suffixes = preferredSuffixes.split(":");
             const assetNames = payload.assets.map((asset) => asset.name);
 
             let selected = null;

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -134,11 +134,16 @@ runs:
 
         archive_name="$({
           RELEASE_PREFIX="$release_prefix" \
+          RELEASE_JSON_PATH="$release_json" \
           VERSION="$version" \
           PREFERRED_SUFFIXES="$(IFS=:; echo "${preferred_suffixes[*]}")" \
           node -e '
             const fs = require("fs");
-            const releaseJsonPath = process.argv[1];
+            const releaseJsonPath = process.env.RELEASE_JSON_PATH;
+            if (!releaseJsonPath) {
+              console.error("Missing RELEASE_JSON_PATH");
+              process.exit(1);
+            }
             const payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
             const prefix = process.env.RELEASE_PREFIX;
             const version = process.env.VERSION;
@@ -165,7 +170,7 @@ runs:
             }
 
             console.log(selected);
-          ' "$release_json"
+          '
         })"
         archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
         checksums_url="https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt"

--- a/docs-hugo-build/action.yml
+++ b/docs-hugo-build/action.yml
@@ -64,11 +64,12 @@ runs:
       env:
         INPUT_HUGO_VERSION: ${{ inputs.hugo-version }}
         INPUT_EXTENDED: ${{ inputs.extended }}
-        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
         version="$INPUT_HUGO_VERSION"
+        checksums_url="https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt"
+
         extended="$INPUT_EXTENDED"
 
         os_name="$(uname -s)"
@@ -111,116 +112,56 @@ runs:
             ;;
         esac
 
-        if ! command -v node >/dev/null 2>&1; then
-          echo "node is required to parse GitHub release metadata" >&2
-          exit 1
-        fi
-
-        release_api_url="https://api.github.com/repos/gohugoio/hugo/releases/tags/v${version}"
-        release_json="$(mktemp)"
-        trap 'rm -f "$release_json"' EXIT
-        curl_args=(-fsSL)
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-          curl_args+=(
-            -H "Authorization: Bearer ${GITHUB_TOKEN}"
-            -H "X-GitHub-Api-Version: 2022-11-28"
-          )
-        fi
-
-        if ! curl "${curl_args[@]}" --retry 3 --retry-delay 2 "$release_api_url" -o "$release_json"; then
-          echo "Failed to fetch Hugo release metadata from $release_api_url. Ensure tag v${version} exists and the workflow is not rate-limited." >&2
-          exit 1
-        fi
-
-        archive_name="$({
-          RELEASE_PREFIX="$release_prefix" \
-          RELEASE_JSON_PATH="$release_json" \
-          VERSION="$version" \
-          PREFERRED_SUFFIXES="$(IFS=:; echo "${preferred_suffixes[*]}")" \
-          node -e '
-            const fs = require("fs");
-            const releaseJsonPath = process.env.RELEASE_JSON_PATH;
-            if (!releaseJsonPath) {
-              console.error("Missing RELEASE_JSON_PATH");
-              process.exit(1);
-            }
-            let payload;
-            try {
-              payload = JSON.parse(fs.readFileSync(releaseJsonPath, "utf8"));
-            } catch (err) {
-              const message = err && err.message ? err.message : String(err);
-              console.error(`Failed to parse release metadata JSON at ${releaseJsonPath}: ${message}`);
-              process.exit(1);
-            }
-            const prefix = process.env.RELEASE_PREFIX;
-            const version = process.env.VERSION;
-            const preferredSuffixes = process.env.PREFERRED_SUFFIXES;
-
-            if (!prefix) {
-              console.error("Missing RELEASE_PREFIX");
-              process.exit(1);
-            }
-            if (!version) {
-              console.error("Missing VERSION");
-              process.exit(1);
-            }
-            if (!preferredSuffixes) {
-              console.error("Missing PREFERRED_SUFFIXES");
-              process.exit(1);
-            }
-            if (!payload || !Array.isArray(payload.assets)) {
-              console.error("Invalid release metadata: missing assets array");
-              process.exit(1);
-            }
-
-            const suffixes = preferredSuffixes.split(":");
-            const assetNames = payload.assets.map((asset) => asset.name);
-
-            let selected = null;
-            for (const suffix of suffixes) {
-              const candidate = `${prefix}_${version}_${suffix}.tar.gz`;
-              if (assetNames.includes(candidate)) {
-                selected = candidate;
-                break;
-              }
-            }
-
-            if (!selected) {
-              console.error(`No matching Hugo archive found for version ${version}`);
-              console.error(`Selected prefix: ${prefix}`);
-              console.error("Available .tar.gz archives:");
-              for (const name of assetNames.filter((name) => name.endsWith(".tar.gz"))) {
-                console.error(`  - ${name}`);
-              }
-              process.exit(1);
-            }
-
-            console.log(selected);
-          '
-        })"
-        archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
-        checksums_url="https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt"
-
         install_root="${RUNNER_TEMP:-$(mktemp -d)}/docs-hugo-build-${version}"
         bin_dir="$install_root/bin"
-        archive_path="$install_root/$archive_name"
         checksums_path="$install_root/hugo_${version}_checksums.txt"
 
         mkdir -p "$bin_dir"
-
-        if ! curl -fsSL --retry 3 --retry-delay 2 "$archive_url" -o "$archive_path"; then
-          echo "Failed to fetch Hugo archive from $archive_url" >&2
-          exit 1
-        fi
 
         if ! curl -fsSL --retry 3 --retry-delay 2 "$checksums_url" -o "$checksums_path"; then
           echo "Failed to fetch Hugo checksums from $checksums_url" >&2
           exit 1
         fi
 
-        checksum_line="$(grep -F "  $archive_name" "$checksums_path" | head -n 1 || true)"
-        if [[ -z "$checksum_line" ]]; then
-          echo "No checksum entry found for ${archive_name} in ${checksums_url}" >&2
+        archive_name=""
+        checksum_line=""
+        for suffix in "${preferred_suffixes[@]}"; do
+          candidate="${release_prefix}_${version}_${suffix}.tar.gz"
+          while IFS= read -r line; do
+            case "$line" in
+              *"  $candidate")
+                archive_name="$candidate"
+                checksum_line="$line"
+                break
+                ;;
+            esac
+          done < "$checksums_path"
+          if [[ -n "$archive_name" ]]; then
+            break
+          fi
+        done
+
+        if [[ -z "$archive_name" || -z "$checksum_line" ]]; then
+          echo "No matching Hugo archive found in published checksums." >&2
+          echo "Hugo version: $version" >&2
+          echo "Release prefix: $release_prefix" >&2
+          echo "Preferred suffixes: ${preferred_suffixes[*]}" >&2
+          echo "Available .tar.gz archives:" >&2
+          while IFS= read -r line; do
+            case "$line" in
+              *".tar.gz")
+                printf '  - %s\n' "${line##*  }" >&2
+                ;;
+            esac
+          done < "$checksums_path"
+          exit 1
+        fi
+
+        archive_url="https://github.com/gohugoio/hugo/releases/download/v${version}/${archive_name}"
+        archive_path="$install_root/$archive_name"
+
+        if ! curl -fsSL --retry 3 --retry-delay 2 "$archive_url" -o "$archive_path"; then
+          echo "Failed to fetch Hugo archive from $archive_url" >&2
           exit 1
         fi
 

--- a/docs-rsync/README.md
+++ b/docs-rsync/README.md
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Stage docs
-        uses: camunda/automation-platform-github-actions/docs-rsync@main
+        uses: camunda/automation-platform-github-actions/docs-rsync@<commit-sha-or-version-tag>
         with:
           mode: stage
           source: ./dist/docs
@@ -81,7 +81,7 @@ jobs:
           live-root: ${{ vars.DOCS_LIVE_ROOT }}
 
       - name: Promote docs to live
-        uses: camunda/automation-platform-github-actions/docs-rsync@main
+        uses: camunda/automation-platform-github-actions/docs-rsync@<commit-sha-or-version-tag>
         with:
           mode: live
           folder: manual/1.2

--- a/docs-rsync/README.md
+++ b/docs-rsync/README.md
@@ -12,6 +12,14 @@ This action is intentionally infrastructure-agnostic. It does not hardcode hostn
 - `dry-run` must be `true` or `false` and defaults to `true`
 - Remote changes happen only when `dry-run` is explicitly set to `false`
 
+## Runner requirements
+
+The runner is expected to provide standard tools used by the action:
+
+- `bash`
+- `ssh`
+- `rsync`
+
 ## Inputs
 
 | Input | Required | Default | Description |

--- a/docs-rsync/action.yml
+++ b/docs-rsync/action.yml
@@ -60,6 +60,15 @@ runs:
         stage_root="$INPUT_STAGE_ROOT"
         live_root="$INPUT_LIVE_ROOT"
 
+        if ! command -v rsync >/dev/null 2>&1; then
+          echo "rsync is required by docs-rsync but was not found on the runner" >&2
+          exit 1
+        fi
+        if ! command -v ssh >/dev/null 2>&1; then
+          echo "ssh is required by docs-rsync but was not found on the runner" >&2
+          exit 1
+        fi
+
         case "$mode" in
           stage|live) ;;
           *)


### PR DESCRIPTION
## Summary

Harden the reusable docs migration actions so they work on the validated `gcp-core-2-default` runner with fewer runtime assumptions and clearer runner-tool diagnostics.

Related to
- https://github.com/camunda/camunda-bpm-platform-maintenance/issues/3005

## What changed

Updated `docs-hugo-build`:

- removed the Ruby/Node-based runtime parser dependency;
- removed GitHub release metadata JSON fetching/parsing;
- now selects the Hugo archive from the published `hugo_${version}_checksums.txt` file;
- keeps the existing preferred OS/architecture suffix order;
- preserves normal vs extended Hugo archive selection;
- preserves checksum verification with `sha256sum` or `shasum`;
- preserves Hugo download, extraction, `GITHUB_PATH`, `GITHUB_OUTPUT`, and final `hugo version` output.

Updated `docs-rsync`:

- added early preflight validation for required runner tools:
  - `rsync`
  - `ssh`
- keeps rsync/SSH behavior unchanged;
- keeps stage/live mode behavior unchanged;
- keeps `dry-run` behavior unchanged.

Updated docs:

- `docs-hugo-build/README.md` documents checksum-file-based archive selection and the current runner requirements;
- `docs-rsync/README.md` documents `bash`, `ssh`, and `rsync` runner requirements;
- reusable action examples use pinned ref placeholders instead of `@main`.

## Why

Runtime validation on `gcp-core-2-default` showed that the docs workflows can start and Vault OIDC/JWT works, but the reusable Hugo build action cannot rely on Ruby or Node being present on the runner.

The Hugo action already downloads the published checksums file for integrity verification, so using that same file for archive selection removes the extra parser/runtime dependency and avoids the GitHub release metadata API request entirely.

A later static dry-run reached `docs-rsync` and showed that `rsync` was missing on the runner. The reusable action now fails early with a clear preflight message when `rsync` or `ssh` is unavailable.

## Preserved

No changes to:

- action inputs;
- Hugo version handling;
- Hugo archive naming format;
- preferred suffix order;
- normal/extended Hugo prefix behavior;
- Linux/Darwin architecture handling;
- checksum verification;
- download URL format;
- consumer Vault authentication;
- SSH options;
- rsync command behavior;
- stage/live mode semantics;
- dry-run semantics.

## Validation

Local validation:

- ran `git diff --check`;
- verified no Ruby dependency remains in `docs-hugo-build`;
- verified no Node dependency remains in `docs-hugo-build`;
- verified the GitHub release metadata API fetch was removed;
- verified Hugo archive selection uses the published checksums file;
- verified checksum verification still exists;
- verified `docs-rsync` checks for `rsync`;
- verified `docs-rsync` checks for `ssh`;
- verified README runner requirements match the action behavior;
- verified reusable action examples no longer use `@main`.

Runtime validation:

Validated from `camunda-docs-static` stage dry-run on `gcp-core-2-default` using this PR branch for the reusable actions.

Confirmed:

- runner pickup works;
- Vault OIDC/JWT secret loading works;
- Hugo installs/builds successfully without Ruby or Node;
- generated static output is validated;
- `docs-rsync` preflight/tooling expectations are explicit;
- `docs-rsync` stage dry-run succeeds.

The static stage dry-run is green with:

- `docs-area=get-started`
- `dry-run=true`

