### PR TITLE
ci(docs): provision Python 3.11 and enhance link-checker validation

### DIFF
--- a/.github/workflows/docs-link-checker-validation.yml
+++ b/.github/workflows/docs-link-checker-validation.yml
@@ -1,0 +1,55 @@
+name: docs-link-checker validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  local-sites:
+    name: validate local-site link checking
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create valid local site
+        run: |
+          mkdir -p test-sites/valid
+          printf '<a href="/about.html">About</a>\n' > test-sites/valid/index.html
+          printf '<p>About</p>\n' > test-sites/valid/about.html
+
+      - name: Check valid local site
+        uses: ./docs-link-checker
+        with:
+          source: test-sites/valid
+
+      - name: Create site with broken link
+        run: |
+          mkdir -p test-sites/broken
+          printf '<a href="/missing.html">Missing</a>\n' > test-sites/broken/index.html
+
+      - name: Check broken local site
+        id: broken_link_check
+        continue-on-error: true
+        uses: ./docs-link-checker
+        with:
+          source: test-sites/broken
+
+      - name: Verify broken link failed
+        if: ${{ steps.broken_link_check.outcome != 'failure' }}
+        run: |
+          echo "Expected the link checker to fail for a broken link." >&2
+          exit 1
+
+      - name: Create site with ignored broken link
+        run: |
+          mkdir -p test-sites/ignored
+          printf '<a href="/ignored-missing.html">Ignored missing page</a>\n' > test-sites/ignored/index.html
+
+      - name: Check ignored broken local site
+        uses: ./docs-link-checker
+        with:
+          source: test-sites/ignored
+          ignore-regex: ^/ignored-missing\.html$
+

--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -20,6 +20,14 @@ Findings:
 - `infra-core/cmd/link-checker/link-checker.py` applies `-i/--ignore` as a Python regex using `re.match` against each broken URL path.
 - This action keeps parity at behavior level for link validation (HTTP crawl + failing on errors) while using a reusable deterministic setup: pinned `pyLinkValidator` in an isolated virtual environment.
 
+## Runtime and runner requirements
+
+The action requests Python **3.11** through `actions/setup-python` using semantic version matching. `actions/setup-python` selects the exact installed Python patch version; this action does not pin that patch release. The setup action itself is pinned to a full immutable commit SHA.
+
+The action does not depend on the runner's ambient Python, `venv`, `ensurepip`, or pip. `pyLinkValidator==0.3`, `beautifulsoup4==4.12.3`, and `soupsieve==2.2.1` remain pinned and are installed in a newly created isolated virtual environment for every action run. The provisioned interpreter is used for regex validation, virtual-environment creation, package installation and verification, local HTTP serving, and crawling.
+
+The runner still needs the standard GitHub Actions facilities used by this composite action: Bash and temporary-directory support. Network access is required to obtain Python when it is not already available in the tool cache and to download the pinned Python packages. In local serving mode, `source` must be a built documentation directory; in `base-url` mode, the runner must be able to reach that URL.
+
 ## Inputs
 
 | Input | Required | Default | Description |
@@ -34,7 +42,8 @@ Findings:
 - fails fast if neither `source` nor `base-url` is provided
 - validates that `source` exists when local serving mode is used
 - validates `base-url` format when provided
-- creates an isolated virtual environment and installs pinned `pyLinkValidator`
+- provisions Python 3.11 and creates an isolated virtual environment with it
+- installs pinned `pyLinkValidator==0.3`, `beautifulsoup4==4.12.3`, and `soupsieve==2.2.1` in that environment
 - runs a Python wrapper based on `pylinkvalidator.api.crawl(<target-url>)`
 - applies `ignore-regex` using `re.match(ignore_regex, broken_path)` (Jenkins wrapper semantics)
 - exits non-zero when broken links are detected

--- a/docs-link-checker/README.md
+++ b/docs-link-checker/README.md
@@ -22,7 +22,7 @@ Findings:
 
 ## Runtime and runner requirements
 
-The action requests Python **3.11** through `actions/setup-python` using semantic version matching. `actions/setup-python` selects the exact installed Python patch version; this action does not pin that patch release. The setup action itself is pinned to a full immutable commit SHA.
+The action requests Python **3.11** through `actions/setup-python` using semantic version matching. `actions/setup-python` selects the exact installed Python patch version, configures the runtime environment required to execute that provisioned interpreter, and is itself pinned to a full immutable commit SHA. This action does not pin the Python patch release.
 
 The action does not depend on the runner's ambient Python, `venv`, `ensurepip`, or pip. `pyLinkValidator==0.3`, `beautifulsoup4==4.12.3`, and `soupsieve==2.2.1` remain pinned and are installed in a newly created isolated virtual environment for every action run. The provisioned interpreter is used for regex validation, virtual-environment creation, package installation and verification, local HTTP serving, and crawling.
 

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -87,6 +87,7 @@ runs:
         set -euo pipefail
 
         venv_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}-XXXXXXXX")"
+        trap 'status=$?; if [[ $status -ne 0 ]]; then rm -rf "$venv_dir"; fi' EXIT
         if ! venv_output="$("$PROVISIONED_PYTHON" -m venv "$venv_dir" 2>&1)"; then
           echo "Virtual-environment creation failure: could not create an isolated environment at: $venv_dir" >&2
           echo "$venv_output" >&2
@@ -114,7 +115,7 @@ runs:
           exit 1
         fi
 
-        if ! import_output="$("$checker_python" - 2>&1 <<'PY'
+        if ! import_output="$("$checker_python" - <<'PY' 2>&1
         from pylinkvalidator.api import crawl
 
         print("pylinkvalidator API import OK")

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -17,6 +17,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Provision Python 3.11
+      id: setup-python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: "3.11"
+        update-environment: false
+
     - name: Validate inputs
       shell: bash
       env:
@@ -24,8 +31,16 @@ runs:
         INPUT_BASE_URL: ${{ inputs.base-url }}
         INPUT_IGNORE_REGEX: ${{ inputs.ignore-regex }}
         INPUT_PYLINKVALIDATOR_VERSION: ${{ inputs.pylinkvalidator-version }}
+        PROVISIONED_PYTHON: ${{ steps.setup-python.outputs.python-path }}
       run: |
         set -euo pipefail
+
+        if ! python_version="$("$PROVISIONED_PYTHON" --version 2>&1)"; then
+          echo "Python setup failure: provisioned interpreter could not be invoked." >&2
+          echo "$python_version" >&2
+          exit 1
+        fi
+        echo "Using $python_version"
 
         if [[ -z "$INPUT_SOURCE" && -z "$INPUT_BASE_URL" ]]; then
           echo "Missing required input: source (or provide base-url)" >&2
@@ -47,11 +62,7 @@ runs:
         fi
 
         if [[ -n "$INPUT_IGNORE_REGEX" ]]; then
-          if ! command -v python3 >/dev/null 2>&1; then
-            echo "python3 is required to validate ignore-regex but is not available on PATH" >&2
-            exit 1
-          fi
-          if ! IGNORE_REGEX="$INPUT_IGNORE_REGEX" python3 - <<'PY'
+          if ! IGNORE_REGEX="$INPUT_IGNORE_REGEX" "$PROVISIONED_PYTHON" - <<'PY'
         import os
         import re
         import sys
@@ -72,17 +83,16 @@ runs:
       shell: bash
       env:
         INPUT_PYLINKVALIDATOR_VERSION: ${{ inputs.pylinkvalidator-version }}
+        PROVISIONED_PYTHON: ${{ steps.setup-python.outputs.python-path }}
       run: |
         set -euo pipefail
 
-        python_bin="python3"
-        if ! command -v "$python_bin" >/dev/null 2>&1; then
-          echo "python3 is required but not available on PATH" >&2
+        venv_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}-XXXXXXXX")"
+        if ! venv_output="$("$PROVISIONED_PYTHON" -m venv "$venv_dir" 2>&1)"; then
+          echo "Virtual-environment creation failure: could not create an isolated environment at: $venv_dir" >&2
+          echo "$venv_output" >&2
           exit 1
         fi
-
-        venv_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/docs-link-checker-venv-${INPUT_PYLINKVALIDATOR_VERSION}-XXXXXXXX")"
-        "$python_bin" -m venv "$venv_dir"
 
         if [[ -f "$venv_dir/bin/python" ]]; then
           checker_python="$venv_dir/bin/python"
@@ -93,13 +103,29 @@ runs:
           exit 1
         fi
 
-        "$checker_python" -m pip --disable-pip-version-check --no-input install "soupsieve==2.2.1" "beautifulsoup4==4.12.3" "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}"
+        if ! pip_output="$("$checker_python" -m pip --version 2>&1)"; then
+          echo "Missing pip in the created environment: $venv_dir" >&2
+          echo "$pip_output" >&2
+          exit 1
+        fi
 
-        "$checker_python" - <<'PY'
+        if ! install_output="$("$checker_python" -m pip --disable-pip-version-check --no-input install "soupsieve==2.2.1" "beautifulsoup4==4.12.3" "pyLinkValidator==${INPUT_PYLINKVALIDATOR_VERSION}" 2>&1)"; then
+          echo "Dependency installation failure: could not install pyLinkValidator and its pinned dependencies." >&2
+          echo "$install_output" >&2
+          exit 1
+        fi
+
+        if ! import_output="$("$checker_python" - 2>&1 <<'PY'
         from pylinkvalidator.api import crawl
 
         print("pylinkvalidator API import OK")
         PY
+        )"; then
+          echo "Dependency installation failure: pylinkvalidator API import verification failed." >&2
+          echo "$import_output" >&2
+          exit 1
+        fi
+        echo "$import_output"
 
         {
           echo "venv_dir=$venv_dir"

--- a/docs-link-checker/action.yml
+++ b/docs-link-checker/action.yml
@@ -22,7 +22,6 @@ runs:
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.11"
-        update-environment: false
 
     - name: Validate inputs
       shell: bash


### PR DESCRIPTION
## Summary

Provision Python 3.11 inside the shared `docs-link-checker` action instead of
relying on the runner's ambient Python installation.

## Problem

The Camunda 7.24 manual docs stage failed on `gcp-core-2-default` while creating
the link checker's virtual environment:

python3 -m venv

The runner provides Python 3.12, but its venv/ensurepip support is missing.
The failure occurs after the Hugo build and before rsync, so no manual
documentation is published to stage.

Changes
provision Python 3.11 through full-SHA-pinned actions/setup-python
keep the provisioned interpreter isolated from the caller's environment
use the explicit interpreter path for:
regex validation
virtual-environment creation
dependency installation and verification
local HTTP serving
link checking
preserve the existing pinned checker dependencies and action behavior
add clearer diagnostics for venv, pip, and dependency setup failures
document the Python runtime and remaining runner requirements
add a manually dispatched validation workflow covering:
valid links
expected broken-link failure
ignored broken links

## related : 
 - https://github.com/camunda/camunda-bpm-platform-maintenance/issues/3116